### PR TITLE
Update benchmarks to randomize values and include SortedContainers

### DIFF
--- a/test_xheap_time.py
+++ b/test_xheap_time.py
@@ -12,20 +12,50 @@ class HeapTimeCase(object):
             'init',
             (
                 'heapq',
-                'from heapq import heapify',
-                'heapify(list(reversed(range({size}))))',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range({size}));'
+                    'random.shuffle(values);'
+                    'from heapq import heapify;'
+                ),
+                'heapify(values)',
                 1,
             ),
             (
                 'Heap',
-                'from xheap import Heap',
-                'Heap(reversed(range({size})))',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range({size}));'
+                    'random.shuffle(values);'
+                    'from xheap import Heap;'
+                ),
+                'Heap(values)',
                 1,
             ),
             (
                 'RemovalHeap',
-                'from xheap import RemovalHeap',
-                'RemovalHeap(reversed(range({size})))',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range({size}));'
+                    'random.shuffle(values);'
+                    'from xheap import RemovalHeap;'
+                ),
+                'RemovalHeap(values)',
+                1,
+            ),
+            (
+                'SortedList',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range({size}));'
+                    'random.shuffle(values);'
+                    'from sortedcontainers import SortedList;'
+                ),
+                'SortedList(values, load=100)',
                 1,
             ),
         ]
@@ -35,20 +65,54 @@ class HeapTimeCase(object):
             'pop',
             (
                 'heapq',
-                'from heapq import heapify, heappop; heap = list(reversed(range({size}))); heapify(heap)',
-                'heappop(heap)',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range({size}));'
+                    'random.shuffle(values);'
+                    'from heapq import heapify, heappop;'
+                    'heapify(values);'
+                ),
+                'heappop(values)',
                 None,
             ),
             (
                 'Heap',
-                'from xheap import Heap; heap = Heap(reversed(range({size})))',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range({size}));'
+                    'random.shuffle(values);'
+                    'from xheap import Heap;'
+                    'heap = Heap(values);'
+                ),
                 'heap.pop()',
                 None,
             ),
             (
                 'RemovalHeap',
-                'from xheap import RemovalHeap; heap = RemovalHeap(reversed(range({size})))',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range({size}));'
+                    'random.shuffle(values);'
+                    'from xheap import RemovalHeap;'
+                    'heap = RemovalHeap(values);'
+                ),
                 'heap.pop()',
+                None,
+            ),
+            (
+                'SortedList',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range({size}));'
+                    'random.shuffle(values);'
+                    'from sortedcontainers import SortedList;'
+                    'heap = SortedList(values, load=100);'
+                ),
+                'heap.pop(0)',
                 None,
             ),
         ]
@@ -58,20 +122,63 @@ class HeapTimeCase(object):
             'push',
             (
                 'heapq',
-                'from heapq import heapify, heappush; heap = list(reversed(range(0, {size}*4, 4))); heapify(heap); i = 1',
-                'heappush(heap, i); i += 4',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range(0, {size} * 2, 2));'
+                    'random.shuffle(values);'
+                    'from heapq import heapify, heappush;'
+                    'heap = list(values);'
+                    'heapify(heap);'
+                    'random.shuffle(values);'
+                    'i = 0;'
+                ),
+                'heappush(heap, values[i] + 1); i += 1',
                 None,
             ),
             (
                 'Heap',
-                'from xheap import Heap; heap = Heap(reversed(range(0, {size}*4, 4))); i = 1',
-                'heap.push(i); i += 4',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range(0, {size} * 2, 2));'
+                    'random.shuffle(values);'
+                    'from xheap import Heap;'
+                    'heap = Heap(values);'
+                    'random.shuffle(values);'
+                    'i = 0;'
+                ),
+                'heap.push(values[i] + 1); i += 1',
                 None,
             ),
             (
                 'RemovalHeap',
-                'from xheap import RemovalHeap; heap = RemovalHeap(reversed(range(0, {size}*4, 4))); i = 1',
-                'heap.push(i); i += 4',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range(0, {size} * 2, 2));'
+                    'random.shuffle(values);'
+                    'from xheap import RemovalHeap;'
+                    'heap = RemovalHeap(values);'
+                    'random.shuffle(values);'
+                    'i = 0;'
+                ),
+                'heap.push(values[i] + 1); i += 1',
+                None,
+            ),
+            (
+                'SortedList',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range(0, {size} * 2, 2));'
+                    'random.shuffle(values);'
+                    'from sortedcontainers import SortedList;'
+                    'heap = SortedList(values, load=100);'
+                    'random.shuffle(values);'
+                    'i = 0;'
+                ),
+                'heap.add(values[i] + 1); i += 1',
                 None,
             ),
         ]
@@ -84,20 +191,50 @@ class OrderHeapTimeCase(object):
             'init',
             (
                 'heapq',
-                'from heapq import heapify',
-                'heapify(list(map(lambda x: (-x, x), range({size}))))',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = [(-x, x) for x in range({size})];'
+                    'random.shuffle(values);'
+                    'from heapq import heapify;'
+                ),
+                'heapify(values)',
                 1,
             ),
             (
                 'OrderHeap',
-                'from xheap import OrderHeap',
-                'OrderHeap(range({size}), key=lambda x: -x)',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range({size}));'
+                    'random.shuffle(values);'
+                    'from xheap import OrderHeap;'
+                ),
+                'OrderHeap(values, key=lambda x: -x)',
                 1,
             ),
             (
                 'XHeap',
-                'from xheap import XHeap',
-                'XHeap(range({size}), key=lambda x: -x)',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range({size}));'
+                    'random.shuffle(values);'
+                    'from xheap import XHeap;'
+                ),
+                'XHeap(values, key=lambda x: -x)',
+                1,
+            ),
+            (
+                'SortedList',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range({size}));'
+                    'random.shuffle(values);'
+                    'from sortedcontainers import SortedList;'
+                ),
+                'SortedList(values, key=lambda x: -x, load=100)',
                 1,
             ),
         ]
@@ -107,20 +244,50 @@ class OrderHeapTimeCase(object):
             'pop',
             (
                 'heapq',
-                'from heapq import heapify, heappop; heap = list(map(lambda x: (-x, x), range({size}))); heapify(heap)',
-                'heappop(heap)[1]',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = [(-x, x) for x in range({size})];'
+                    'from heapq import heapify, heappop;'
+                    'heapify(values);'
+                ),
+                'heappop(values)[1]',
                 None,
             ),
             (
                 'OrderHeap',
-                'from xheap import OrderHeap; heap = OrderHeap(range({size}), key=lambda x: -x)',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range({size}));'
+                    'from xheap import OrderHeap;'
+                    'heap = OrderHeap(values, key=lambda x: -x);'
+                ),
                 'heap.pop()',
                 None,
             ),
             (
                 'XHeap',
-                'from xheap import XHeap; heap = XHeap(range({size}), key=lambda x: -x)',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range({size}));'
+                    'from xheap import XHeap;'
+                    'heap = XHeap(values, key=lambda x: -x);'
+                ),
                 'heap.pop()',
+                None,
+            ),
+            (
+                'SortedList',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range({size}));'
+                    'from sortedcontainers import SortedList;'
+                    'heap = SortedList(values, key=lambda x: -x, load=100);'
+                ),
+                'heap.pop(0)',
                 None,
             ),
         ]
@@ -130,20 +297,63 @@ class OrderHeapTimeCase(object):
             'push',
             (
                 'heapq',
-                'from heapq import heapify, heappush; heap = list(map(lambda x: (-x, x), range(0, {size}*4, 4))); heapify(heap); i = 1',
-                'heappush(heap, (-i, i)); i += 4',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = [(-x, x) for x in range(0, {size} * 2, 2)];'
+                    'random.shuffle(values);'
+                    'from heapq import heapify, heappush;'
+                    'heap = list(values);'
+                    'heapify(heap);'
+                    'random.shuffle(values);'
+                    'i = 0;'
+                ),
+                'heappush(heap, (values[i][0] - 1, values[i][1] + 1)); i += 1',
                 None,
             ),
             (
                 'OrderHeap',
-                'from xheap import OrderHeap; heap = OrderHeap(range(0, {size}*4, 4), key=lambda x: -x); i = 1',
-                'heap.push(i); i += 4',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range(0, {size} * 2, 2));'
+                    'random.shuffle(values);'
+                    'from xheap import OrderHeap;'
+                    'heap = OrderHeap(values, key=lambda x: -x);'
+                    'random.shuffle(values);'
+                    'i = 0;'
+                ),
+                'heap.push(values[i] + 1); i += 1',
                 None,
             ),
             (
                 'XHeap',
-                'from xheap import XHeap; heap = XHeap(range(0, {size}*4, 4), key=lambda x: -x); i = 1',
-                'heap.push(i); i += 4',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range(0, {size} * 2, 2));'
+                    'random.shuffle(values);'
+                    'from xheap import XHeap;'
+                    'heap = XHeap(values, key=lambda x: -x);'
+                    'random.shuffle(values);'
+                    'i = 0;'
+                ),
+                'heap.push(values[i] + 1); i += 1',
+                None,
+            ),
+            (
+                'SortedList',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range(0, {size} * 2, 2));'
+                    'random.shuffle(values);'
+                    'from sortedcontainers import SortedList;'
+                    'heap = SortedList(values, key=lambda x: -x, load=100);'
+                    'random.shuffle(values);'
+                    'i = 0;'
+                ),
+                'heap.add(values[i] + 1); i += 1',
                 None,
             ),
         ]
@@ -156,24 +366,69 @@ class RemovalHeapTimeCase(object):
             'remove',
             (
                 'RemovalHeap',
-                'from xheap import RemovalHeap; heap = RemovalHeap(map(lambda x: (-x, x), reversed(range({size})))); i = {size}//2',
-                'heap.remove((-i, i)); i += 1',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range({size}));'
+                    'random.shuffle(values);'
+                    'from xheap import RemovalHeap;'
+                    'heap = RemovalHeap((-x, x) for x in values);'
+                    'i = 0;'
+                    'random.shuffle(values);'
+                ),
+                (
+                    'heap.remove((-values[i], values[i]));'
+                    'i += 1;'
+                ),
                 None,
             ),
             (
                 'XHeap',
-                'from xheap import XHeap; heap = XHeap(reversed(range({size})), key=lambda x: -x); i = {size}//2',
-                'heap.remove(i); i += 1',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range({size}));'
+                    'random.shuffle(values);'
+                    'from xheap import XHeap;'
+                    'heap = XHeap(values, key=lambda x: -x);'
+                    'i = 0;'
+                    'random.shuffle(values);'
+                ),
+                (
+                    'heap.remove(values[i]);'
+                    'i += 1;'
+                ),
+                None,
+            ),
+            (
+                'SortedList',
+                (
+                    'import random;'
+                    'random.seed(0);'
+                    'values = list(range({size}));'
+                    'random.shuffle(values);'
+                    'from sortedcontainers import SortedList;'
+                    'heap = SortedList(values, key=lambda x: -x, load=100);'
+                    'i = 0;'
+                    'random.shuffle(values);'
+                ),
+                (
+                    'heap.remove(values[i]);'
+                    'i += 1;'
+                ),
                 None,
             ),
         ]
 
 
 initial_sizes = [10**3, 10**4, 10**5, 10**6]
-repetitions = 10000
+repetitions = 5
 def perform_time_configs(configs):
     for _, setup, stmt, number in configs:
-        yield [min(repeat(stmt.format(size=size), setup.format(size=size), number=(number or size//32), repeat=repetitions)) for size in initial_sizes]
+        try:
+            yield [min(repeat(stmt.format(size=size), setup.format(size=size), number=(number or size), repeat=repetitions)) for size in initial_sizes]
+        except ImportError as exc:
+            pass
 
 
 for htc in (HeapTimeCase(), OrderHeapTimeCase(), RemovalHeapTimeCase()):


### PR DESCRIPTION
Update benchmarks to randomize values and include SortedContainers.
- Use `random` module to shuffle values.
- Take minimum of 5 trials.
- When `number` is `None` use `size`. Previously `size // 32` was used but this avoided the `sweep` rebuilding step.
- Add support for benchmarking [SortedContainers](http://www.grantjenks.com/docs/sortedcontainers/). If not installed then data is omitted.

Results
- `sortedcontainers.SortedList` does more than maintain a heap. All elements are maintained in sort order. Initializing and pushing values is therefore 6-8x slower.
- `pop` operations are actually faster than `RemovalHeap` and `XHeap` types.

Output
- MacBook Pro (Retina, 15-inch, Late 2013)
- 2.6 GHz Intel Core i7

```
$ time python3 test_xheap_time.py 
init heapq        0.03 ( 1.00x)  0.33 ( 1.00x)  3.79 ( 1.00x) 93.79 ( 1.00x)
     Heap         0.03 ( 1.09x)  0.37 ( 1.11x)  4.73 ( 1.25x) 122.28 ( 1.30x)
     RemovalHeap  0.06 ( 2.02x)  0.75 ( 2.25x) 12.74 ( 3.37x) 285.14 ( 3.04x)
     SortedList   0.17 ( 5.82x)  2.33 ( 7.00x) 32.51 ( 8.59x) 552.27 ( 5.89x)
--------------------------------------------------------------------
pop  heapq        0.19 ( 1.00x)  2.60 ( 1.00x) 40.70 ( 1.00x) 1067.35 ( 1.00x)
     Heap         0.32 ( 1.69x)  3.90 ( 1.50x) 53.11 ( 1.30x) 1193.74 ( 1.12x)
     RemovalHeap  1.02 ( 5.43x) 11.34 ( 4.36x) 150.55 ( 3.70x) 2041.92 ( 1.91x)
     SortedList   0.88 ( 4.71x)  8.98 ( 3.45x) 97.45 ( 2.39x) 961.48 ( 0.90x)
--------------------------------------------------------------------
push heapq        0.20 ( 1.00x)  2.19 ( 1.00x) 27.70 ( 1.00x) 388.39 ( 1.00x)
     Heap         0.32 ( 1.66x)  3.33 ( 1.52x) 39.06 ( 1.41x) 518.95 ( 1.34x)
     RemovalHeap  0.50 ( 2.54x)  5.03 ( 2.30x) 66.34 ( 2.39x) 794.87 ( 2.05x)
     SortedList   1.34 ( 6.84x) 14.37 ( 6.56x) 172.48 ( 6.23x) 2630.77 ( 6.77x)
--------------------------------------------------------------------
--------------------------------------------------------------------
init heapq       0.07 ( 1.00x)  0.76 ( 1.00x) 17.80 ( 1.00x) 207.62 ( 1.00x)
     OrderHeap   0.27 ( 4.16x)  2.92 ( 3.87x) 44.18 ( 2.48x) 540.26 ( 2.60x)
     XHeap       0.27 ( 4.20x)  3.11 ( 4.12x) 52.16 ( 2.93x) 695.72 ( 3.35x)
     SortedList  0.45 ( 6.95x)  5.23 ( 6.93x) 73.06 ( 4.10x) 1066.84 ( 5.14x)
--------------------------------------------------------------------
pop  heapq       0.41 ( 1.00x)  5.39 ( 1.00x) 70.80 ( 1.00x) 874.57 ( 1.00x)
     OrderHeap   0.81 ( 1.98x)  9.65 ( 1.79x) 113.82 ( 1.61x) 1256.28 ( 1.44x)
     XHeap       1.27 ( 3.09x) 14.09 ( 2.61x) 160.37 ( 2.27x) 1737.44 ( 1.99x)
     SortedList  0.97 ( 2.37x)  9.73 ( 1.80x) 99.67 ( 1.41x) 1056.54 ( 1.21x)
--------------------------------------------------------------------
push heapq       0.35 ( 1.00x)  3.83 ( 1.00x) 72.33 ( 1.00x) 823.93 ( 1.00x)
     OrderHeap   0.83 ( 2.37x)  8.39 ( 2.19x) 103.38 ( 1.43x) 1068.92 ( 1.30x)
     XHeap       0.72 ( 2.07x)  7.42 ( 1.94x) 103.69 ( 1.43x) 1101.38 ( 1.34x)
     SortedList  1.95 ( 5.59x) 21.93 ( 5.73x) 272.52 ( 3.77x) 3723.27 ( 4.52x)
--------------------------------------------------------------------
--------------------------------------------------------------------
remove RemovalHeap  1.11 ( 1.00x) 11.80 ( 1.00x) 161.20 ( 1.00x) 1878.20 ( 1.00x)
       XHeap        1.21 ( 1.08x) 12.33 ( 1.05x) 172.23 ( 1.07x) 2300.82 ( 1.23x)
       SortedList   1.94 ( 1.74x) 20.54 ( 1.74x) 241.43 ( 1.50x) 3366.33 ( 1.79x)
--------------------------------------------------------------------
--------------------------------------------------------------------

real    6m38.725s
user    6m32.422s
sys 0m6.197s
```
